### PR TITLE
Fix copy-paste of translated address

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -42,7 +42,7 @@
           <div class="form-group col">
             <div class="input-group">
               <div class="input-group-addon">Address:</div>
-              <input type="text" class="form-control" id="resultAddress" [disabled]="true" name="resultAddress" [(ngModel)]="result.resultAddress" style="cursor: initial">
+              <input type="text" class="form-control" id="resultAddress" readonly="true" name="resultAddress" [(ngModel)]="result.resultAddress" style="cursor: initial">
             </div>
           </div>
         </div>


### PR DESCRIPTION
(Disclaimer: I'm a newbie web developer, and this is also my first-ever pull request, so let me know if I messed up the process or you have suggestions on how to improve my work.)

The tool seems to disallow copy-pasting from the translated address field, so I've updated the form to be `readonly` instead of completely `disabled`.