### PR TITLE
QR code for CashAddress should use normal lowercase format

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -50,7 +50,7 @@
           </div>
         </div>
         <div *ngIf="cashAddr && cashAddrUpperCase" class="qrcode">
-          <ngx-qrcode qrc-value="{{cashAddrUpperCase}}" qrc-errorCorrectionLevel="M">
+          <ngx-qrcode qrc-value="{{cashAddr}}" qrc-errorCorrectionLevel="M">
           </ngx-qrcode>
         </div>
       </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -49,7 +49,7 @@
             </div>
           </div>
         </div>
-        <div *ngIf="cashAddr && cashAddrUpperCase" class="qrcode">
+        <div *ngIf="cashAddr" class="qrcode">
           <ngx-qrcode qrc-value="{{cashAddr}}" qrc-errorCorrectionLevel="M">
           </ngx-qrcode>
         </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,7 +12,6 @@ export class AppComponent {
   public cashAddr: string;
   public copayAddr: string;
   public legacyAddr: string;
-  public cashAddrUpperCase: string;
 
   constructor(
     private addressTranslatorService: AddressTranslatorService
@@ -23,6 +22,5 @@ export class AppComponent {
     this.legacyAddr = this.addressTranslatorService.translateLegacyAddress(addr);
     this.copayAddr = this.addressTranslatorService.translateCopayAddress(this.legacyAddr);
     this.cashAddr = this.addressTranslatorService.translateCashAddress(this.copayAddr);
-    this.cashAddrUpperCase = this.cashAddr.toUpperCase();
   }
 }


### PR DESCRIPTION
Was there a reason to make the address represented in the QR code all uppercase?
I am not sure how the variable `cashAddrUpperCase` would be of use, otherwise.

Although technically one could argue that both the uppercase and the lowercase format of the cashAddr string are valid.. 